### PR TITLE
fixed bot.checkRole method

### DIFF
--- a/src/bot.js
+++ b/src/bot.js
@@ -4,26 +4,11 @@ const bot = new Discord.Client()
 var level = require('./helpers/level')
 const masterID = '127060142935113728'
 const { prefix } = require('./constants')
+//additional botfunctions in rolechecker.js, probably rename at a later time
+const roleChecker = require('./constants/rolechecker');
 const commands = require('./commands')
 
 // bot methods
-bot.checkRole = async (msg, roleArr) => {
-  if (msg.author.id === masterID) return true
-  for (let i = roleArr.length - 1; i >= 0; i--) {
-    if (msg.guild.roles.find('name', roleArr[i]) !== undefined) {
-      let foundRole = msg.guild.roles.find('name', roleArr[i])
-      if (msg.member.roles.has(foundRole.id)) {
-        await console.log(`${msg.author.username} has role ${roleArr[i]}`)
-        return true
-      }
-    } else {
-      console.log(`WARNING! Role not found: ${roleArr[i]}`)
-      return false
-    }
-  }
-  return false
-}
-
 bot.on('ready', async () => {
   await bot.user.setStatus(`online`, `Say ${prefix}help`)
   console.log(`DUST-3 Online`)

--- a/src/commands/reboot.js
+++ b/src/commands/reboot.js
@@ -4,10 +4,10 @@ module.exports = {
   description: 'Reboots the bot. Must have privileges to execute.',
   discrete: true,
   process: async msg => {
-    if (bot.checkRole(msg, ['Elder', 'Head Scribe'])) {
+    if (await bot.checkRole(msg, ['Head Scribe', 'Elder'])) {
       await msg.channel.send('*Beep boop, click*')
-      console.log('Being shut down by ' + msg.author.username)
-      process.exit(0)
+      await console.log('Being shut down by ' + msg.author.username)
+      process.exit();
     } else {
       bot.reject(msg)
     }

--- a/src/commands/xp.js
+++ b/src/commands/xp.js
@@ -5,8 +5,11 @@ module.exports = {
   description: 'Give XP to a user. Need permissions.',
   usage: '@<username> <#>',
   process: async (msg, argument) => {
-    if (bot.checkRole(msg, ['Elder', 'Council'])) {
+    if (await bot.checkRole(msg, ['Elder', 'Council'])) {
       await level.give(msg, argument)
-    } else bot.reject(msg)
+    } 
+    else {
+      await bot.reject(msg)
+    }
   }
 }

--- a/src/constants/rolechecker.js
+++ b/src/constants/rolechecker.js
@@ -2,26 +2,25 @@ const bot = require('../bot')
 const masterID = '127060142935113728'
 
 bot.checkRole = async (msg, roleArr) => {
-  var returnobj;
-  var authorroles = [];
-  var rolesStr = "";
-    for (let i = roleArr.length - 1; i >= 0; i--) {
-      if (await msg.guild.roles.find('name', roleArr[i]) != undefined) {
-        let foundRole = msg.guild.roles.find('name', roleArr[i]);
-        if (await msg.member.roles.has(foundRole.id)) {
-          authorroles.push(" "+foundRole.name)
-        }
+  var hasRole;
+  var authorRoles = [];
+  for (let i = roleArr.length - 1; i >= 0; i--) {
+    if (await msg.guild.roles.find('name', roleArr[i]) != undefined) {
+      let foundRole = await msg.guild.roles.find('name', roleArr[i]);
+      if (await msg.member.roles.has(foundRole.id)) {
+        authorRoles.push(foundRole.name)
       }
     }
-
-    if(authorroles.length > 0) { 
-      returnobj = true;
-      rolesStr = rolesStr + authorroles + " ";
-      await console.log(`${msg.author.username} has role(s)${rolesStr}`)
-    }
-    else { 
-      returnobj = false;
-      await console.log(`${msg.author.username} has none of the required roles`)
-    }
-    return returnobj;
   }
+
+  if(authorRoles.length > 0) { 
+    hasRole = true;
+    authorRoles = authorRoles.join(", ")
+    await console.log(`${msg.author.username} has role(s) ${authorRoles}`)
+  }
+  else { 
+    hasRole = false;
+    await console.log(`${msg.author.username} has none of the required roles`)
+  }
+  return hasRole;
+}

--- a/src/constants/rolechecker.js
+++ b/src/constants/rolechecker.js
@@ -1,0 +1,27 @@
+const bot = require('../bot')
+const masterID = '127060142935113728'
+
+bot.checkRole = async (msg, roleArr) => {
+  var returnobj;
+  var authorroles = [];
+  var rolesStr = "";
+    for (let i = roleArr.length - 1; i >= 0; i--) {
+      if (await msg.guild.roles.find('name', roleArr[i]) != undefined) {
+        let foundRole = msg.guild.roles.find('name', roleArr[i]);
+        if (await msg.member.roles.has(foundRole.id)) {
+          authorroles.push(" "+foundRole.name)
+        }
+      }
+    }
+
+    if(authorroles.length > 0) { 
+      returnobj = true;
+      rolesStr = rolesStr + authorroles + " ";
+      await console.log(`${msg.author.username} has role(s)${rolesStr}`)
+    }
+    else { 
+      returnobj = false;
+      await console.log(`${msg.author.username} has none of the required roles`)
+    }
+    return returnobj;
+  }


### PR DESCRIPTION
rolechecker.js: moved bot.checkRole from bot.js to constants/rolechecker.js. checking roles works now. returns only true if user is in at least on of the required roles. console output for logging purposes.

xp.js & reboot.js: bot.checkRole call fixed with await. granting xp works, console still throws some errors which have to do with level.js.

please add to master.